### PR TITLE
Corrected terms for finding ECS Task URL

### DIFF
--- a/workshop/content/Labs/lab1/Sec4_AccessApp/_index.en.md
+++ b/workshop/content/Labs/lab1/Sec4_AccessApp/_index.en.md
@@ -121,13 +121,13 @@ GET  db_cache_redis_time
 {{% img "GetDBCacheTime.png" "Get command" %}}
 
 
-Following the description of caching above, we would expect to also see hash keys for the cache. The reason you might not see those in the output above is that the keys are set to expire after a few seconds. If you want to assure yourself that things are working as expected call the db update and redis check back-to back from the terminal. To do so, first set the IP address of the ECS cluster:
+Following the description of caching above, we would expect to also see hash keys for the cache. The reason you might not see those in the output above is that the keys are set to expire after a few seconds. If you want to assure yourself that things are working as expected call the db update and redis check back-to back from the terminal. To do so, first set the IP address of the ECS cluster task, located in task found [here](https://console.aws.amazon.com/ecs/home?region=us-east-1#/clusters/CacheDemoECSService1/tasks):
 
 ```bash
 export ECS_IP=<IP>
 ```
 
-where `<IP>` is replaced by the IP address of the ECS cluster you recorded in the previous section. Then run the following commands:
+where `<IP>` is replaced by the IP address of the ECS task you recorded in the previous section. Then run the following commands:
 
 ```bash
 curl http://${ECS_IP}/start_db_run


### PR DESCRIPTION
Existing docs say cluster instead of task.